### PR TITLE
Fix spurious test failure with previously loaded module

### DIFF
--- a/t/01-basics.t
+++ b/t/01-basics.t
@@ -11,8 +11,8 @@ require lib::filter;
 
 subtest "disallow" => sub {
     lib::filter->import(disallow => 'IPC::Cmd;List::Util');
-    dies_ok  { require IPC::Cmd };
-    dies_ok  { require List::Util };
+    dies_ok  { local %INC = %INC; delete $INC{'IPC/Cmd.pm'}; require IPC::Cmd };
+    dies_ok  { local %INC = %INC; delete $INC{'List/Util.pm'}; require List::Util };
     lives_ok { require IO::Socket };
     lib::filter->unimport;
 };


### PR DESCRIPTION
Recent development versions of `Test::More` load `List::Util`. Therefore, the `@INC` hook is skipped when it comes to testing whether the attempt to `require` `List::Util` dies.

Fix this spurious test failure by deleting each disallowed module from `%INC` prior to testing.

This addresses my earlier [bug report](https://github.com/perlancar/perl-lib-filter/issues/1).
