### PR TITLE
Normalize INC paths + Win32 fixes

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -22,3 +22,7 @@ strict=0
 warnings=0
 Config=0
 Module::CoreList=0
+
+; https://metacpan.org/pod/Dist::Zilla::Plugin::OSPrereqs
+[OSPrereqs / MSWin32]
+Win32::Symlink=0.06


### PR DESCRIPTION
I custom real_path sub routine has been added, to 

1) normalize INC paths so that $core_inc, $noncore_inc, and $orig_inc* variables so make the comparisons being made more reliable, especially when symlinks are used, which can lead to situations where archlib(exp) and privlib(exp) defines can actually differ from what's in in @INC, which seems to be especially possible under relocatable perls, and

2) to provide a common way of resolving the symlink-analogs in Win32/NTFS filesystems (junctions and symlinks) as well as symlinks on Unix-like systems, so a proper normalized path can be obtained on both Unix-like and Win32 platforms.